### PR TITLE
Added missing line on Windows, to match the expected result

### DIFF
--- a/src/result-conversions-test.cpp
+++ b/src/result-conversions-test.cpp
@@ -650,6 +650,8 @@ TEST_CASE("result-conversions-test", "[odbc]") {
 	#ifndef _WIN32
 		//TODO Windows converts SQL_C_WCHAR to SQL_C_CHAR, because we are a ASCII driver, for now
 		test_conversion("text", "", SQL_C_WCHAR, "SQL_C_WCHAR", 1, 0);
+	#else
+		test_conversion("text", "", SQL_C_CHAR, "SQL_C_WCHAR", 1, 0);
 	#endif
 
 	test_conversion("timestamp", "2011-02-15 15:49:18", SQL_C_CHAR, "SQL_C_CHAR", 19, 0);


### PR DESCRIPTION
Untested attempt to fix issue.

The expected result has an extra line, which is missing in the output on Windows
`'' (text) as SQL_C_WCHAR: `

We have no conditional expected outputs based on OS, so my naive fix for this was to add the extra line.